### PR TITLE
依据微信支付文档, 设定沙盒模式的固定费用.

### DIFF
--- a/api/app/Models/v1/MiniProgram.php
+++ b/api/app/Models/v1/MiniProgram.php
@@ -256,6 +256,9 @@ class MiniProgram extends Model
         $config = config('wechat.payment.default');
         $config['notify_url'] = request()->root().'/api/v1/app/paymentNotify';
         $app = Factory::payment($config);
+        if($config['sandbox'] == true){
+            $fee = '101';
+        }      
         $result = $app->order->unify([
             'body' => $body,
             'out_trade_no' => $number,


### PR DESCRIPTION

如果沙盒环境，支付时始终提示缺少参数total_fee, 此错误可以忽略，为正常情况。
详见： https://mp.weixin.qq.com/s/JEQnD_NmqNvYnCi5hCKW9g