### PR TITLE
修复切换购物车tab, 空购物车元素一闪显示的问题

### DIFF
--- a/trade/Dsshop/pages/cart/cart.vue
+++ b/trade/Dsshop/pages/cart/cart.vue
@@ -139,13 +139,7 @@
 			}
 		},
 		watch:{
-			//显示空白页
-			cartList(e){
-				let empty = e.length === 0 ? true: false;
-				if(this.empty !== empty){
-					this.empty = empty;
-				}
-			}
+
 		},
 		computed:{
 			...mapState(['hasLogin'])
@@ -314,6 +308,7 @@
 				})
 				this.allChecked = checked;
 				this.total = Number(total.toFixed(2));
+				this.empty = false;
 			},
 			//重新加载数据
 			loadCart(){


### PR DESCRIPTION
原方式, 当购物车里有商品时, 切换tab时, 先显示购物车是空的, 然后才显示购物车里的内容. 体验不太好. 现在的方式稍微好一点.