### PR TITLE
修复新用户无收货地址导致的错误

### DIFF
--- a/trade/Dsshop/pages/order/createOrder.vue
+++ b/trade/Dsshop/pages/order/createOrder.vue
@@ -219,7 +219,7 @@
 			getOne(){
 				const that = this
 				Address.getOne(this.order, function(res){
-					that.addressData = res.shipping
+					that.addressData = res.shipping ? res.shipping : ''
 					that.carriage = res.carriage ? res.carriage : 0
 					that.outPocketTotal() //实付金额
 				})


### PR DESCRIPTION
用户创建订单时, 假如无收货地址, 返回的 res.shipping为null, 赋值给addressData会报错.