### PR TITLE
$api.prePage()不可靠, 临时解决方案

### DIFF
--- a/trade/Dsshop/pages/address/address.vue
+++ b/trade/Dsshop/pages/address/address.vue
@@ -72,8 +72,10 @@ export default {
 						if (confirmRes.confirm) {
 							Address.checkSubmit(item, function(res) {
 								if (that.type === '1') {
-									that.$api.prePage().refreshAddress(item);
-									uni.navigateBack();
+									if(typeof that.$api.prePage().refreshAddress === "function" && typeof that.$api.prePage().refreshAddress !== "undefined") {
+										that.$api.prePage().refreshAddress(item);
+										uni.navigateBack();
+									}
 								} else {
 									that.$api.msg('设置成功');
 									that.loadData();
@@ -81,21 +83,29 @@ export default {
 							});
 						} else {
 							if (that.type === '1') {
-								that.$api.prePage().refreshAddress(item);
-								uni.navigateBack();
+								if(typeof that.$api.prePage().refreshAddress === "function" && typeof that.$api.prePage().refreshAddress !== "undefined") {
+									that.$api.prePage().refreshAddress(item);
+									uni.navigateBack();
+								}
 							}
 						}
 					}
 				});
 			} else {
-				that.$api.prePage().refreshAddress(item);
-				uni.navigateBack();
+				if(that.$api.prePage().route == 'pages/user/user')
+					return false
+				if(typeof that.$api.prePage().refreshAddress === "function" && typeof that.$api.prePage().refreshAddress !== "undefined") {
+					that.$api.prePage().refreshAddress(item);
+					uni.navigateBack();
+				}
 			}
 
 			if (this.source == 1) {
 				//this.$api.prePage()获取上一页实例，在App.vue定义
-				this.$api.prePage().addressData = item;
-				uni.navigateBack();
+				if(typeof that.$api.prePage().addressData !== "undefined") {
+					this.$api.prePage().addressData = item;
+					uni.navigateBack();
+				}
 			}
 		},
 		addAddress(type, item) {

--- a/trade/Dsshop/pages/address/addressManage.vue
+++ b/trade/Dsshop/pages/address/addressManage.vue
@@ -56,7 +56,7 @@
 			if(option.type==='edit'){
 				title = '编辑收货地址'
 			}
-			if(option.data){
+			if(option.data && option.data != 'undefined'){
 				this.addressData = JSON.parse(option.data)
 				console.log(this.addressData,this.addressData)
 			}
@@ -137,19 +137,23 @@
 				data.cellphone = Number(data.cellphone)
 				if(data.id){
 					Address.updateSubmit(data,function(res){
-						that.$api.prePage().refreshList()
-						that.$api.msg(`地址${that.manageType=='edit' ? '修改': '添加'}成功`);
-						setTimeout(()=>{
-							uni.navigateBack()
-						}, 800)
+						if(typeof that.$api.prePage().refreshList === "function" && typeof that.$api.prePage().refreshList !== "undefined") {
+							that.$api.prePage().refreshList()
+							that.$api.msg(`地址${that.manageType=='edit' ? '修改': '添加'}成功`);
+							setTimeout(()=>{
+								uni.navigateBack()
+							}, 800)
+						}
 					})
 				}else{
 					Address.createSubmit(data,function(res){
-						that.$api.prePage().refreshList()
-						that.$api.msg(`地址${that.manageType=='edit' ? '修改': '添加'}成功`);
-						setTimeout(()=>{
-							uni.navigateBack()
-						}, 800)
+						if(typeof that.$api.prePage().refreshList === "function" && typeof that.$api.prePage().refreshList !== "undefined") {
+							that.$api.prePage().refreshList()
+							that.$api.msg(`地址${that.manageType=='edit' ? '修改': '添加'}成功`);
+							setTimeout(()=>{
+								uni.navigateBack()
+							}, 800)
+						}
 					})
 				}
 			},


### PR DESCRIPTION
地址管理有两个入口, 一个在用户中心, 一个在购买商品时. 如果设置多个不同的地址, 或者进入不同的页面, 就很容易出现
`[system] TypeError: that.$api.prePage() is undefined`
`[system] TypeError: that.$api.prePage().refreshList is undefined`
`[system] TypeError: that.$api.prePage().refreshAddressis undefined`

加了一些规避方法, 但仍然无法彻底避免, 临时采用这种方法可以规避报错.