### PR TITLE
解决低分辨率屏幕下, 多次打开/关闭Sidebar后, 弹出错误的菜单遮挡界面的问题. 

### DIFF
--- a/admin/src/views/Layout/components/Sidebar/index.vue
+++ b/admin/src/views/Layout/components/Sidebar/index.vue
@@ -26,7 +26,6 @@ export default {
       'sidebar'
     ]),
     isCollapse() {
-      return !this.sidebar.opened
     }
   }
 }


### PR DESCRIPTION
比如进入开发模式后, 就会出现遮挡菜单