### PR TITLE
修复本地调试跨域问题

### DIFF
--- a/api/app/Http/Middleware/EnableCrossRequestMiddleware.php
+++ b/api/app/Http/Middleware/EnableCrossRequestMiddleware.php
@@ -15,9 +15,10 @@ class EnableCrossRequestMiddleware
      */
     public function handle($request, Closure $next)
     {
+        $origin = $request->server('HTTP_ORIGIN') ? $request->server('HTTP_ORIGIN') : '';
         $resp = $next($request);
         $resp->headers->add([
-            'Access-Control-Allow-Origin' => '*',
+            'Access-Control-Allow-Origin' => $origin,
             'Access-Control-Allow-Headers' => 'Origin, Content-Type, Cookie, X-CSRF-TOKEN, Accept, Authorization,applyid,openid,apply-secret,versionid, X-XSRF-TOKEN',
             'Access-Control-Expose-Headers' => 'Authorization, authenticated',
             'Access-Control-Allow-Methods' => 'GET, POST, PATCH, PUT, OPTIONS,DELETE',

--- a/api/config/dsshop.php
+++ b/api/config/dsshop.php
@@ -20,7 +20,7 @@ return [
     'homestead' => env('HOMESTEAD_WINDOWS', false),
     'failuretime' => env('VERIFICATION_CODE_FAILURE_TIME', 60), // 验证码失效时间秒，默认60秒
     'versions' => env('API_VERSIONS', 1),   //当前版本
-    'applySecret' => env('PROJECT_KEY', 'base64:szoJ3mSx/5U7zOsJfU7s4pSahiwdh01x6badmz5FtCM='), //API密钥串
+    'applySecret' => env('APP_KEY', 'base64:szoJ3mSx/5U7zOsJfU7s4pSahiwdh01x6badmz5FtCM='), //API密钥串
     'orderOvertime' => env('ORDER_OVERTIME', 1440),  // 订单超时时间(分钟)
     'automaticReceivingState' => env('AUTOMATIC_RECEIVING_STATE', true),  // 是否开启自动收货
     'automaticReceiving' => env('AUTOMATIC_RECEIVING', 7),  // 多少天后自动收货(天)


### PR DESCRIPTION
变更文件：api\app\Http\Middleware\EnableCrossRequestMiddleware.php
问题现象：本地调试时会出现跨域问题，定位原因为Access-Control-Allow-Origin值为*
修复方式：使用$request->server('HTTP_ORIGIN')获取客户端ORIGIN头并赋值到Access-Control-Allow-Origin
修复时间：2021年5月26日 0:12