### PR TITLE
修复编辑商品时, 假如商品图片列表已有图片, 这时如果保存, 会出现移动临时文件夹中不存在的图片的报错.

### DIFF
--- a/api/app/Helpers/functions.php
+++ b/api/app/Helpers/functions.php
@@ -237,6 +237,9 @@ function imgPathShift($new, $img)
         $path = 'storage/temporary/';
         $img = explode($path, $img);
         if (count($img) == 2) {
+            if (!Storage::exists('public/temporary/' . $img['1'])) { //临时文件如果不在, 则是表明图片已存在, 就不用再次移动一个不存在的图片
+                return request()->root() . '/storage/image/'.$new.'/' . $img['1'];
+            }
             Storage::move('public/temporary/' . $img['1'], 'public/image/' . $new . '/' . $img['1']);
             //拷贝不同规格的图片
             $imageSpecification = config('image.specification');


### PR DESCRIPTION
  具体报错信息如下:

   "message": "File not found at path: public/temporary/uBJL41630476392.jpg",
    "exception": "League\\Flysystem\\FileNotFoundException",
    "file": "/var/shop/api/vendor/league/flysystem/src/Filesystem.php",